### PR TITLE
add $(CPPFLAGS) to loader targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,16 +23,16 @@ kernel.img:	loader
 	$(OBJCOPY) -O binary $< $@
 
 loader:	loader.o
-	$(CC) $^ -o $@ $(LDFLAGS) -T ldscript_loader.X
+	$(CC) $^ -o $@ $(LDFLAGS) $(CPPFLAGS)  -T ldscript_loader.X
 
 loader.o:	loader.S rsp.img
-	$(CC) -c $< -o $@ $(LDFLAGS)
+	$(CC) -c $< -o $@ $(LDFLAGS) $(CPPFLAGS) 
 
 rsp.img:	rsp
 	$(OBJCOPY) -O binary $< $@
 
 rsp:	$(OBJS)
-	$(CC) $^ -o $@ $(LDFLAGS) -T ldscript.X
+	$(CC) $^ -o $@ $(LDFLAGS) $(CPPFLAGS)  -T ldscript.X
 
 %.o:	%.c
 	$(CC) -c $< -o $@ $(CPPFLAGS)


### PR DESCRIPTION
I'm getting this errro
arm-linux-gnueabi-gcc -c loader.S -o loader.o -nostdlib -ffreestanding -Wl,--build-id=none
loader.S: Assembler messages:
loader.S:37: Error: selected processor does not support ARM mode `cpsid if'

May you help with it?
